### PR TITLE
Fix hard-coded log path

### DIFF
--- a/clintlr-gui/src/main/java/org/monarchinitiative/clintlr/gui/MainApp.java
+++ b/clintlr-gui/src/main/java/org/monarchinitiative/clintlr/gui/MainApp.java
@@ -37,11 +37,6 @@ public class MainApp  extends Application {
     public void init() {
         String[] args = getParameters().getRaw().toArray(String[]::new);
         //Set before the logger starts. The property will be picked up by logback.xml
-        System.setProperty("log.name", "clintlr-gui/clintlr.log");
-//        DateTimeFormatter dtf = DateTimeFormatter.ofPattern("yyyy/MM/dd HH:mm:ss");
-//        LocalDateTime now = LocalDateTime.now();
-//        String dtime = dtf.format(now);
-//        LOGGER.trace("Starting ClintLR: " + dtime);
         context = new SpringApplicationBuilder(MainApp.class)
                 .headless(false)
                 .run(args);

--- a/clintlr-gui/src/main/java/org/monarchinitiative/clintlr/gui/config/ClintLRConfig.java
+++ b/clintlr-gui/src/main/java/org/monarchinitiative/clintlr/gui/config/ClintLRConfig.java
@@ -23,6 +23,11 @@ public class ClintLRConfig {
      */
     private static final String CONFIG_FILE_BASENAME = "clintlr.properties";
 
+    /**
+     * The name of the log file. Note, the log file name MUST match the file name in the <code>logback.xml</code>.
+     */
+    public static final String CLINTLR_LOG_FILENAME = "clintlr.log";
+
     @Bean
     public ExecutorService executorService() {
         return Executors.newFixedThreadPool(Runtime.getRuntime().availableProcessors());

--- a/clintlr-gui/src/main/java/org/monarchinitiative/clintlr/gui/controller/MainController.java
+++ b/clintlr-gui/src/main/java/org/monarchinitiative/clintlr/gui/controller/MainController.java
@@ -39,6 +39,7 @@ import java.util.stream.Collectors;
 import org.monarchinitiative.clintlr.core.io.PretestProbaAdjustmentIO;
 import org.monarchinitiative.clintlr.core.mondo.MondoStats;
 import org.monarchinitiative.clintlr.gui.PopUps;
+import org.monarchinitiative.clintlr.gui.config.ClintLRConfig;
 import org.monarchinitiative.clintlr.gui.resources.*;
 import org.monarchinitiative.clintlr.gui.UrlBrowser;
 import org.monarchinitiative.clintlr.gui.config.AppProperties;
@@ -360,8 +361,8 @@ public class MainController {
 
     @FXML
     public void showLog(ActionEvent e) {
-        String logFile = "clintlr-gui/clintlr.log";
-        LogViewerFactory factory = new LogViewerFactory(logFile);
+        Path logPath = Path.of(System.getProperty("java.io.tmpdir")).resolve(ClintLRConfig.CLINTLR_LOG_FILENAME);
+        LogViewerFactory factory = new LogViewerFactory(logPath);
         factory.display();
         e.consume();
     }

--- a/clintlr-gui/src/main/java/org/monarchinitiative/clintlr/gui/ui/logviewer/LogViewerFactory.java
+++ b/clintlr-gui/src/main/java/org/monarchinitiative/clintlr/gui/ui/logviewer/LogViewerFactory.java
@@ -33,9 +33,10 @@ import org.monarchinitiative.clintlr.gui.PopUps;
 
 
 import java.io.BufferedReader;
-import java.io.File;
-import java.io.FileReader;
 import java.io.IOException;
+import java.nio.file.FileAlreadyExistsException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Optional;
 
 
@@ -44,9 +45,9 @@ import java.util.Optional;
  * according to the level of the log item.
  */
 public class LogViewerFactory {
-    private final String logpath;
+    private final Path logpath;
 
-    public LogViewerFactory(String path) {
+    public LogViewerFactory(Path path) {
         this.logpath= path;
     }
 
@@ -58,10 +59,13 @@ public class LogViewerFactory {
     public void display() {
         Log log = new Log();
         MyLogger mylogger = new MyLogger(log, "main");
-        File logfile = new File(logpath);
         try{
-            logfile.createNewFile(); // if file already exists will do nothing
-            BufferedReader br = new BufferedReader(new FileReader(logfile));
+            try {
+                Files.createFile(logpath);
+            } catch (FileAlreadyExistsException fe) {
+                // if file already exists will do nothing
+            }
+            BufferedReader br = Files.newBufferedReader(logpath);
             String line;
             while ((line=br.readLine())!=null) {
                 Optional<LogRecord> opt = LogRecord.fromLine(line);

--- a/clintlr-gui/src/main/resources/logback.xml
+++ b/clintlr-gui/src/main/resources/logback.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
 <appender name="FileAppender" class="ch.qos.logback.core.FileAppender">
-    <file>${log.name}</file>
+    <file>${java.io.tmpdir}${file.separator}clintlr.log</file>
     <append>true</append>
     <immediateFlush>true</immediateFlush>
     <encoder>


### PR DESCRIPTION
Fixes a bug where a file with a weird name is created when running from graal image.

The log file is created in a platform-specific temporary directory (`java.io.tmpdir`) and is later read by the log viewer. Thanks to this, the user will not see weird files in his folders. At the same time, the temporary folder should always be writable, so the log viewer should work fine. 