### PR TITLE
Fix repeated execution

### DIFF
--- a/clintlr-gui/src/main/java/org/monarchinitiative/clintlr/gui/tasks/LiricalRunTask.java
+++ b/clintlr-gui/src/main/java/org/monarchinitiative/clintlr/gui/tasks/LiricalRunTask.java
@@ -7,7 +7,6 @@ import org.monarchinitiative.lirical.core.Lirical;
 import org.monarchinitiative.lirical.core.analysis.AnalysisData;
 import org.monarchinitiative.lirical.core.analysis.AnalysisOptions;
 import org.monarchinitiative.lirical.core.analysis.AnalysisResults;
-import org.monarchinitiative.lirical.core.analysis.LiricalAnalysisRunner;
 import org.monarchinitiative.lirical.core.io.VariantParser;
 import org.monarchinitiative.lirical.core.model.*;
 import org.monarchinitiative.lirical.core.output.AnalysisResultsMetadata;


### PR DESCRIPTION
@mabeckwith 

I ended up simplifying the fix even more - with no need for the additional property. All we should do is *not* to use the analysis runner in the closeable context within ClintLR's LIRICAL task. That's the core of the proposed change.

Can you pls test if it works OK on your side?